### PR TITLE
GPX-580: Enable CGO builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,7 @@ jobs:
         run: go get .
 
       - name: Build
-        run: CGO_ENABLED=0 go build -o ./.cache/ -v ./...
+        run: go build -o ./.cache/ -v ./...
 
       - name: Copy build
         run: cp ./.cache/multena-proxy ./multena-proxy


### PR DESCRIPTION
Because of the upgrade to ubi9, CGO can be enabled again